### PR TITLE
I recommend merging imports together (you may reject this PR if you disagree)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,4 @@
-use std::env;
-use std::error::Error;
-use std::ffi::OsString;
-use std::fmt;
-use std::fs::File;
-use std::path::Path;
-use std::process::Command;
+use std::{env, error::Error, ffi::OsString, fmt, fs::File, path::Path, process::Command};
 
 #[derive(Debug)]
 struct MissingScriptError(String);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
-use std::{env, error::Error, ffi::OsString, fmt, fs::File, process::Command};
+use std::{
+    collections::HashMap, env, error::Error, ffi::OsString, fmt, fs::File, process::Command,
+};
 
 #[derive(Debug)]
 struct MissingScriptError(String);


### PR DESCRIPTION
## Why?

`rust-analyzer`'s auto-import feature always assume the imports to be merged, so when an import of similar origin already exists, it always writes to existing import instead of creating new line.

## Alternative

You might feel that this style is not clean enough and reject this PR. This would mean that we have to either live with slightly inferior IDE support or creating an issue on the rust-analyzer repo and temporarily live with slightly inferior IDE support.