### PR TITLE
Non-zero status code should cause errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,16 +10,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "derive_more"
+version = "0.99.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "pipe-trait"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd92f5561e74c246a0b7332e09d2364afb40b67d152c4520b3ba2a7d3dea5b3"
+
+[[package]]
 name = "pn"
 version = "0.0.0"
 dependencies = [
  "ansi_term",
+ "derive_more",
+ "pipe-trait",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 serde_json="1.0"
 serde = { version = "1.0", features = ["derive"] }
 ansi_term = "0.12.1"
+derive_more = "0.99.14"
+pipe-trait = "0.3.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,50 @@
 use ansi_term::Color::{Black, Red};
+use derive_more::Display;
+use pipe_trait::Pipe;
 use serde::Deserialize;
 use std::{
     collections::HashMap,
     env,
     error::Error,
     ffi::OsString,
-    fmt,
     fs::File,
-    process::{exit, Child, Command, ExitStatus, Stdio},
+    num::NonZeroI32,
+    process::{exit, Command, Stdio},
 };
 
-#[derive(Debug)]
-struct MissingScriptError(String);
-
-impl fmt::Display for MissingScriptError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Missing script {:?}", self.0)
-    }
+/// Error types emitted by `pn` itself.
+#[derive(Debug, Display)]
+enum PnError {
+    /// Script not found when running `pn run`.
+    #[display(fmt = "Missing script {:?}", name)]
+    MissingScript { name: String },
+    /// Script ran by `pn run` exits with non-zero status code.
+    #[display(fmt = "Script {:?} exits with non-zero status code {}", name, status)]
+    ScriptError { name: String, status: NonZeroI32 },
+    /// Subprocess finishes but without a status code.
+    #[display(fmt = "Command {:?} has ended unexpectedly", command)]
+    UnexpectedTermination { command: String },
+    /// Other errors.
+    #[display(fmt = "{}", error)]
+    Other { error: Box<dyn Error> },
 }
 
-impl Error for MissingScriptError {}
-
+/// The main error type.
 #[derive(Debug)]
-struct FailureStatus(ExitStatus);
-
-impl fmt::Display for FailureStatus {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(code) = self.0.code() {
-            write!(f, "Process exits with non-zero status code {:?}", code)
-        } else {
-            write!(f, "An unknown problem occurred during execution of process")
-        }
-    }
+enum MainError {
+    /// Errors emitted by `pn` itself.
+    Pn(PnError),
+    /// The `pnpm` subprocess exits with non-zero status code.
+    Pnpm(NonZeroI32),
 }
 
-impl Error for FailureStatus {}
+impl MainError {
+    fn from_dyn(error: impl Error + 'static) -> Self {
+        MainError::Pn(PnError::Other {
+            error: Box::new(error),
+        })
+    }
+}
 
 /// Structure of `package.json`.
 #[derive(Debug, Clone, Deserialize)]
@@ -45,28 +55,38 @@ struct NodeManifest {
 }
 
 fn main() {
-    if let Err(error) = run() {
-        eprintln!(
-            "{prefix} {error}",
-            prefix = Black.on(Red).paint("\u{2009}ERROR\u{2009}"),
-            error = Red.paint(error.to_string()),
-        );
-        exit(1);
+    match run() {
+        Ok(()) => {}
+        Err(MainError::Pnpm(status)) => exit(status.get()),
+        Err(MainError::Pn(error)) => {
+            eprintln!(
+                "{prefix} {error}",
+                prefix = Black.on(Red).paint("\u{2009}ERROR\u{2009}"),
+                error = Red.paint(error.to_string()),
+            );
+            exit(1);
+        }
     }
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<(), MainError> {
     let args: Vec<String> = std::env::args().collect();
     match &*args[1] {
         "run" | "run-script" => {
-            let manifest: NodeManifest = serde_json::de::from_reader(File::open("package.json")?)?;
-            let script_name = &args[2];
-            if let Some(script) = manifest.scripts.get(script_name) {
-                eprintln!("> {:?}", script);
-                run_script(script)?;
+            let manifest = "package.json"
+                .pipe(File::open)
+                .map_err(MainError::from_dyn)?
+                .pipe(serde_json::de::from_reader::<_, NodeManifest>)
+                .map_err(MainError::from_dyn)?;
+            let name = args[2].clone();
+            if let Some(command) = manifest.scripts.get(&name) {
+                eprintln!("> {:?}", command);
+                run_script(name, command.clone())?;
                 Ok(())
             } else {
-                Err(Box::new(MissingScriptError(script_name.into())))
+                PnError::MissingScript { name }
+                    .pipe(MainError::Pn)
+                    .pipe(Err)
             }
         }
         "install" | "i" | "update" | "up" => {
@@ -74,44 +94,58 @@ fn run() -> Result<(), Box<dyn Error>> {
             Ok(())
         }
         _ => {
-            run_script(&args[1..].join(" "))?;
-            Ok(())
+            // run_script(&args[1..].join(" "))?;
+            // Ok(())
+            panic!("What does this part mean, @zkochan? Why doesn't pn just pass this to pnpm to handle?")
         }
     }
 }
 
-fn wait_for_child(mut child: Child) -> Result<(), Box<dyn Error>> {
-    let status = child.wait()?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(Box::new(FailureStatus(status)))
-    }
-}
-
-fn run_script(script: &str) -> Result<(), Box<dyn Error>> {
+fn run_script(name: String, command: String) -> Result<(), MainError> {
     let mut path_env = OsString::from("node_modules/.bin");
     if let Some(path) = env::var_os("PATH") {
         path_env.push(":");
         path_env.push(path);
     }
-    let child = Command::new("sh")
+    let status = Command::new("sh")
         .env("PATH", path_env)
         .arg("-c")
-        .arg(script)
+        .arg(&command)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
-        .spawn()?;
-    wait_for_child(child)
+        .spawn()
+        .map_err(MainError::from_dyn)?
+        .wait()
+        .map_err(MainError::from_dyn)?
+        .code()
+        .map(NonZeroI32::new);
+    match status {
+        Some(None) => return Ok(()),
+        Some(Some(status)) => PnError::ScriptError { name, status },
+        None => PnError::UnexpectedTermination { command },
+    }
+    .pipe(MainError::Pn)
+    .pipe(Err)
 }
 
-fn pass_to_pnpm(args: &[String]) -> Result<(), Box<dyn Error>> {
-    let child = Command::new("pnpm")
+fn pass_to_pnpm(args: &[String]) -> Result<(), MainError> {
+    let status = Command::new("pnpm")
         .args(args)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
-        .spawn()?;
-    wait_for_child(child)
+        .spawn()
+        .map_err(MainError::from_dyn)?
+        .wait()
+        .map_err(MainError::from_dyn)?
+        .code()
+        .map(NonZeroI32::new);
+    Err(match status {
+        Some(None) => return Ok(()),
+        Some(Some(status)) => MainError::Pnpm(status),
+        None => MainError::Pn(PnError::UnexpectedTermination {
+            command: format!("pnpm {}", args.join(" ")),
+        }),
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,22 +81,15 @@ fn run() -> Result<(), MainError> {
             let name = args[2].clone();
             if let Some(command) = manifest.scripts.get(&name) {
                 eprintln!("> {:?}", command);
-                run_script(name, command.clone())?;
-                Ok(())
+                run_script(name, command.clone())
             } else {
                 PnError::MissingScript { name }
                     .pipe(MainError::Pn)
                     .pipe(Err)
             }
         }
-        "install" | "i" | "update" | "up" => {
-            pass_to_pnpm(&args[1..])?;
-            Ok(())
-        }
-        _ => {
-            pass_to_sub(args[1..].join(" "))?;
-            Ok(())
-        }
+        "install" | "i" | "update" | "up" => pass_to_pnpm(&args[1..]),
+        _ => pass_to_sub(args[1..].join(" ")),
     }
 }
 


### PR DESCRIPTION
Previously, the Rust wrapper exits with status code 0 even if the subprocess it spawns exits with non-zero status code. This PR makes it returns 1 when the subprocess exits with non-zero status code.