### PR TITLE
Option 1: Deduplicate the matcher

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,33 +7,51 @@ pub struct Cli {
     /// Run the command on the root workspace project.
     #[clap(short, long)]
     pub workspace_root: bool,
-    #[clap(subcommand)]
-    pub command: Command,
-}
 
-#[derive(Debug, Subcommand)]
-#[clap(rename_all = "kebab-case")]
-pub enum Command {
-    /// Runs a defined package script.
-    #[clap(alias = "run-script")]
-    Run(RunArgs),
-    /// Installs all dependencies of the project in the current working directory.
-    /// When executed inside a workspace, installs all dependencies of all projects.
-    #[clap(alias = "i")]
-    Install(PassedThroughArgs),
-    /// Updates packages to their latest version based on the specified range.
-    /// You can use "*" in package name to update all packages with the same pattern.
-    #[clap(alias = "up")]
-    Update(PassedThroughArgs),
-    /// Execute a shell command in scope of a project.
-    #[clap(external_subcommand)]
-    Other(Vec<String>),
+    /// Passing command to pnpm.
+    #[clap(flatten)]
+    pub passed_through: Option<PassedThroughArgs>,
+
+    /// Execute commands or scripts.
+    #[clap(subcommand)]
+    pub exec: Option<ExecCommand>,
 }
 
 #[derive(Debug, Args)]
 #[clap(rename_all = "kebab-case")]
 pub struct PassedThroughArgs {
+    /// Command to pass to pnpm.
+    #[clap(subcommand)]
+    pub cmd: PassedThroughCommand,
+
+    /// Arguments to pass to pnpm.
     pub args: Vec<String>,
+}
+
+#[derive(Debug, Subcommand)]
+#[clap(rename_all = "kebab-case")]
+pub enum PassedThroughCommand {
+    /// Installs all dependencies of the project in the current working directory.
+    /// When executed inside a workspace, installs all dependencies of all projects.
+    #[clap(alias = "i")]
+    Install,
+
+    /// Updates packages to their latest version based on the specified range.
+    /// You can use "*" in package name to update all packages with the same pattern.
+    #[clap(alias = "up")]
+    Update,
+}
+
+#[derive(Debug, Subcommand)]
+#[clap(rename_all = "kebab-case")]
+pub enum ExecCommand {
+    /// Runs a defined package script.
+    #[clap(alias = "run-script")]
+    Run(RunArgs),
+
+    /// Execute a shell command in scope of a project.
+    #[clap(external_subcommand)]
+    Other(Vec<String>),
 }
 
 /// Runs a defined package script.

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,13 +4,13 @@ use cli::Cli;
 use error::{MainError, PnError};
 use pipe_trait::Pipe;
 use serde::Deserialize;
-use std::path::Path;
 use std::{
     collections::HashMap,
     env,
     ffi::OsString,
     fs::File,
     num::NonZeroI32,
+    path::Path,
     process::{exit, Command, Stdio},
 };
 


### PR DESCRIPTION
It is possible to make the matcher less "ugly", but at a cost: The code is now a bit more complicated.

Now you need to ask yourself a question: Are you going replace `Install` and `Update` with your own implementation in Rust at some point? If you plan to, then I suggest **NOT** merging this.

If you still choose to do this, don't merge it yet, instead, let me know so that I may polish it further.

**Note:** This PR targets `workspace-root` as the base branch, not `master`. 