### PR TITLE
refactor: Remove star import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use ansi_term::Color::{Black, Red};
-use clap::*;
+use clap::Parser;
 use cli::{Cli, PassedThroughArgs};
 use error::{MainError, PnError};
 use itertools::Itertools;


### PR DESCRIPTION
You wouldn't want to see name conflict errors to suddenly appear out-of-nowhere.