### PR TITLE
Update `build-fs-tree`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,16 +99,15 @@ dependencies = [
 
 [[package]]
 name = "build-fs-tree"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85199b032e7d08f84570a62dc4b59d4ef37e094939d634e9dddd161515ec3ba9"
+checksum = "c6394082e1d2e5228ec0622f936448df81bd3f88741a9db21055e4a711affbe2"
 dependencies = [
  "derive_more",
  "pipe-trait",
  "serde",
  "serde_yaml",
  "text-block-macros",
- "thiserror",
 ]
 
 [[package]]
@@ -563,26 +562,6 @@ name = "text-block-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8b59b4da1c1717deaf1de80f0179a9d8b4ac91c986d5fd9f4a8ff177b84049"
-
-[[package]]
-name = "thiserror"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ itertools = "0.10.5"
 
 [dev-dependencies]
 assert_cmd = "2.0.5"
-build-fs-tree = "0.4.1"
+build-fs-tree = "0.5.0"
 tempfile = "3.5.0"

--- a/tests/test_main.rs
+++ b/tests/test_main.rs
@@ -34,7 +34,7 @@ fn run_from_workspace_root() {
             },
         },
     });
-    tree.build(&temp_dir.path().to_path_buf()).unwrap();
+    tree.build(temp_dir.path()).unwrap();
 
     Command::cargo_bin("pn")
         .unwrap()

--- a/tests/test_main.rs
+++ b/tests/test_main.rs
@@ -34,7 +34,7 @@ fn run_from_workspace_root() {
             },
         },
     });
-    tree.build(temp_dir.path()).unwrap();
+    tree.build(&temp_dir).unwrap();
 
     Command::cargo_bin("pn")
         .unwrap()


### PR DESCRIPTION
Yesterday, I see `&temp_dir.path().to_path_buf()` in your code and realized a flaw in my library. Today, I fixed this flaw.

---

Also, when editing `build-fs-tree`, I find out that `derive_more::{Display, Error}` is better than `thiserror::Error` because it can automatically add flexible trait bounds, which helped me remove a tons of unnecessary trait bounds in my trait declarations (refs: https://github.com/KSXGitHub/build-fs-tree/commit/e0ade5453d647fd395933f730f79243fd43579b2, https://github.com/KSXGitHub/build-fs-tree/commit/1dee32a0d822da54262702bc50c0835b291ed5a4, https://github.com/KSXGitHub/build-fs-tree/commit/6041bf36a4d44072b3a349b295f567d2f05566cc, https://github.com/KSXGitHub/build-fs-tree/commit/e748d226bc30031a463e0a6641e867c5a89e22c8). So if you do plan to use `thiserror` in the future, my advice would be "DON'T", just `derive_more` is sufficient.