### PR TITLE
Stop using `actions-rs/clippy-check`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,11 +83,7 @@ jobs:
           default: 'true'
 
       - name: Use clippy to lint code
-        uses: actions-rs/clippy-check@v1
-        with:
-          name: Clippy Report (${{ hashFiles('rust-toolchain') }}, ${{ matrix.os }})
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings
+        run: cargo clippy -- -D warnings
 
   fmt_check:
     name: Fmt


### PR DESCRIPTION
Although it gives us nice annotations in our code, it can sometimes fail unexpectedly.

Furthermore, it will fail to authenticate if someone outside of pnpm teams make a pull request.