### PR TITLE
Use `thiserror` crate to derive `std::error::Error` for error enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "yansi",
 ]
 
@@ -558,9 +559,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -591,6 +592,26 @@ name = "text-block-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f8b59b4da1c1717deaf1de80f0179a9d8b4ac91c986d5fd9f4a8ff177b84049"
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 indexmap = { version = "1.9.3", features = ["serde"] }
 yansi = "0.5.1"
-derive_more = { version = "1.0", features = ["display", "from", "into"] }
+derive_more = { version = "1.0", features = ["display", "into"] }
+thiserror = "2.0.3"
 pipe-trait = "0.4.0"
 clap = { version = "4.3.2", features = ["derive"] }
 lets_find_up = "0.0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,70 +1,71 @@
 use crate::shell_quoted::ShellQuoted;
-use derive_more::{Display, From};
 use std::{env::JoinPathsError, io, num::NonZeroI32, path::PathBuf};
 
 /// Error types emitted by `pn` itself.
-#[derive(Debug, Display)]
+#[derive(Debug, thiserror::Error)]
 pub enum PnError {
     /// Script not found when running `pn run`.
-    #[display("Missing script: {name}")]
+    #[error("Missing script: {name}")]
     MissingScript { name: String },
 
     /// Script ran by `pn run` exits with non-zero status code.
-    #[display("Command failed with exit code {status}")]
+    #[error("Command failed with exit code {status}")]
     ScriptError { name: String, status: NonZeroI32 },
 
     /// Subprocess finishes but without a status code.
-    #[display("Command ended unexpectedly: {command}")]
+    #[error("Command ended unexpectedly: {command}")]
     UnexpectedTermination { command: ShellQuoted },
 
     /// Fail to spawn a subprocess.
-    #[display("Failed to spawn process: {_0}")]
-    SpawnProcessError(io::Error),
+    #[error("Failed to spawn process: {0}")]
+    SpawnProcessError(#[source] io::Error),
 
     /// Fail to wait for the subprocess to finish.
-    #[display("Failed to wait for the process: {_0}")]
-    WaitProcessError(io::Error),
+    #[error("Failed to wait for the process: {0}")]
+    WaitProcessError(#[source] io::Error),
 
     /// The program receives --workspace-root outside a workspace.
-    #[display("--workspace-root may only be used in a workspace")]
+    #[error("--workspace-root may only be used in a workspace")]
     NotInWorkspace,
 
     /// No package manifest.
-    #[display("File not found: {file:?}")]
+    #[error("File not found: {file:?}")]
     NoPkgManifest { file: PathBuf },
 
     /// Error related to filesystem operation.
-    #[display("{path:?}: {error}")]
-    FsError { path: PathBuf, error: io::Error },
+    #[error("{path:?}: {error}")]
+    FsError { path: PathBuf, #[source] error: io::Error },
 
     /// Error emitted by [`lets_find_up`]'s functions.
-    #[display("Failed to find {file_name:?} from {start_dir:?} upward: {error}")]
+    #[error("Failed to find {file_name:?} from {start_dir:?} upward: {error}")]
     FindUpError {
         start_dir: PathBuf,
         file_name: &'static str,
+        #[source]
         error: io::Error,
     },
 
     /// An error is encountered when write to stdout.
-    #[display("Failed to write to stdout: {_0}")]
+    #[error("Failed to write to stdout: {0}")]
     WriteStdoutError(io::Error),
 
     /// Parse JSON error.
-    #[display("Failed to parse {file:?}: {message}")]
+    #[error("Failed to parse {file:?}: {message}")]
     ParseJsonError { file: PathBuf, message: String },
 
     /// Failed to prepend `node_modules/.bin` to `PATH`.
-    #[display("Cannot add `node_modules/.bin` to PATH: {_0}")]
+    #[error("Cannot add `node_modules/.bin` to PATH: {0}")]
     NodeBinPathError(JoinPathsError),
 }
 
 /// The main error type.
-#[derive(Debug, Display, From)]
+#[derive(Debug, thiserror::Error)]
 pub enum MainError {
     /// Errors emitted by `pn` itself.
-    Pn(PnError),
+    #[error(transparent)]
+    Pn(#[from] PnError),
 
     /// The subprocess that takes control exits with non-zero status code.
-    #[from(ignore)]
+    #[error("{0}")]
     Sub(NonZeroI32),
 }


### PR DESCRIPTION
This PR uses the popular https://github.com/dtolnay/thiserror crate for deriving `std::error::Error` (and `Display` and optionally `From`) for the error enums `PnError` and `MainError`.